### PR TITLE
Port to FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,27 +110,29 @@ ifeq ($(origin PKG_CONFIG), undefined)
   endif
 endif
 
-ifeq ($(origin LIBNL_CFLAGS) $(origin LIBNL_LDLIBS), undefined undefined)
-  LIBNL_NAME ?= libnl-3.0
-  ifeq ($(shell $(PKG_CONFIG) --modversion $(LIBNL_NAME) 2>/dev/null),)
-    $(error No $(LIBNL_NAME) development libraries found!)
+ifeq ($(uname), Linux)
+  ifeq ($(origin LIBNL_CFLAGS) $(origin LIBNL_LDLIBS), undefined undefined)
+    LIBNL_NAME ?= libnl-3.0
+    ifeq ($(shell $(PKG_CONFIG) --modversion $(LIBNL_NAME) 2>/dev/null),)
+      $(error No $(LIBNL_NAME) development libraries found!)
+    endif
+    LIBNL_CFLAGS += $(shell $(PKG_CONFIG) --cflags $(LIBNL_NAME))
+    LIBNL_LDLIBS +=  $(shell $(PKG_CONFIG) --libs $(LIBNL_NAME))
   endif
-  LIBNL_CFLAGS += $(shell $(PKG_CONFIG) --cflags $(LIBNL_NAME))
-  LIBNL_LDLIBS +=  $(shell $(PKG_CONFIG) --libs $(LIBNL_NAME))
-endif
-CFLAGS += $(LIBNL_CFLAGS)
-LDLIBS += $(LIBNL_LDLIBS)
+  CFLAGS += $(LIBNL_CFLAGS)
+  LDLIBS += $(LIBNL_LDLIBS)
 
-ifeq ($(origin LIBNL_GENL_CFLAGS) $(origin LIBNL_GENL_LDLIBS), undefined undefined)
-  LIBNL_GENL_NAME ?= libnl-genl-3.0
-  ifeq ($(shell $(PKG_CONFIG) --modversion $(LIBNL_GENL_NAME) 2>/dev/null),)
-    $(error No $(LIBNL_GENL_NAME) development libraries found!)
+  ifeq ($(origin LIBNL_GENL_CFLAGS) $(origin LIBNL_GENL_LDLIBS), undefined undefined)
+    LIBNL_GENL_NAME ?= libnl-genl-3.0
+    ifeq ($(shell $(PKG_CONFIG) --modversion $(LIBNL_GENL_NAME) 2>/dev/null),)
+      $(error No $(LIBNL_GENL_NAME) development libraries found!)
+    endif
+    LIBNL_GENL_CFLAGS += $(shell $(PKG_CONFIG) --cflags $(LIBNL_GENL_NAME))
+    LIBNL_GENL_LDLIBS += $(shell $(PKG_CONFIG) --libs $(LIBNL_GENL_NAME))
   endif
-  LIBNL_GENL_CFLAGS += $(shell $(PKG_CONFIG) --cflags $(LIBNL_GENL_NAME))
-  LIBNL_GENL_LDLIBS += $(shell $(PKG_CONFIG) --libs $(LIBNL_GENL_NAME))
+  CFLAGS += $(LIBNL_GENL_CFLAGS)
+  LDLIBS += $(LIBNL_GENL_LDLIBS)
 endif
-CFLAGS += $(LIBNL_GENL_CFLAGS)
-LDLIBS += $(LIBNL_GENL_LDLIBS)
 
 # standard build tools
 CC ?= gcc


### PR DESCRIPTION
In the aim of porting BATMAN to FreeBSD: https://github.com/obiwac/freebsd-gsoc/pull/1

FreeBSD uses [snl(3)](https://man.freebsd.org/cgi/man.cgi?query=snl&apropos=0&sektion=0&manpath=FreeBSD+13.2-RELEASE+and+Ports&arch=default&format=html) (introduced in 13.2), whereas Linux programs (`batctl` included) typically use [`libnl`](https://github.com/thom311/libnl/tree/main). The two possible solution are:

- Make `batctl` use snl(3) on FreeBSD, keep `libnl` on Linux.
- Port `libnl` to FreeBSD, so `batctl` can basically be built "as is", and other programs can benefit from this.

In fine I'll probably go with the second option.

There are also a few issues w.r.t. e.g. it expecting the `batman-adv` kernel module to be loaded (Linux name), whereas on FreeBSD it's called `batman_adv` (actually that's only part of the issue, because `batctl` looks for `/sys/module/batman_adv/version` to determine if the module is loaded or not).